### PR TITLE
Break Dockerfile for test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ docker ]
   pull_request:
+    branches: [ docker ]
   workflow_dispatch:
 
 jobs:

--- a/HW1/cloud-hw1-market/Dockerfile
+++ b/HW1/cloud-hw1-market/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY --from=builder /app/target/release/cloud-hw1-market ./cloud-hw1-market
-COPY run.sh .
+COPY nonexistent.sh .
 
 RUN chmod +x ./cloud-hw1-market ./run.sh
 


### PR DESCRIPTION
本次 PR 目的是實做 GitHub Actions 正確偵測 Dockerfile 錯誤並導致 CI 失敗。故意修改 Dockerfile 包含以下錯誤：

**缺少檔案 COPY**：
   ```Dockerfile
   COPY nonexistent.sh .
   ```
   - 該檔案並不存在於專案目錄中，COPY 指令會失敗。